### PR TITLE
Add script for syncing changes back to l10n-central

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -33,5 +33,4 @@ jobs:
         shell: bash
       - run: git merge --no-edit $(tr '\n' ' ' < firefox-locales)
         shell: bash
-      - run: git tag --force l10n-central cthulhu
-      - run: git push --force origin cthulhu l10n-central
+      - run: git push origin cthulhu

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -33,4 +33,5 @@ jobs:
         shell: bash
       - run: git merge --no-edit $(tr '\n' ' ' < firefox-locales)
         shell: bash
-      - run: git push origin cthulhu
+      - run: git tag --force l10n-central cthulhu
+      - run: git push --force origin cthulhu l10n-central

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-name: Sync to l10n-central
+name: Sync from main to locale branches
 
 on:
   workflow_dispatch:
@@ -14,11 +14,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt-get install -y git-filter-repo mercurial
-      - run: sudo curl -O https://raw.githubusercontent.com/glandium/git-cinnabar/master/download.py
-        working-directory: /usr/local/bin
-      - run: sudo python download.py && sudo chmod a+rx git-cinnabar
-        working-directory: /usr/local/bin
+      - run: sudo apt-get install -y git-filter-repo
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -26,19 +22,16 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config fetch.prune true
-          git config push.default upstream
       - run: |
-          for lc in $(git diff-tree --no-commit-id --name-only l10n-central main); do
-            git remote add $lc hg::https://hg.mozilla.org/l10n-central/$lc/;
-            git fetch $lc;
-            git tag base-$lc l10n-central;
+          for lc in $(git diff-tree --no-commit-id --name-only last-sync main); do
+            git tag base-$lc last-sync;
             git branch next-$lc main;
             git filter-repo --subdirectory-filter $lc --force --refs next-$lc base-$lc;
-            git checkout --track -b $lc $lc/branches/default/tip;
+            git checkout --track origin/$lc;
             git cherry-pick base-$lc..next-$lc;
-            git push; # TODO: Authentication for hg.mozilla.org
           done
         shell: bash
-      - run: git tag --force l10n-central main
-      - run: git push --force origin l10n-central
+      - run: git push origin $(git diff-tree --no-commit-id --name-only last-sync main | tr '\n' ' ')
+        shell: bash
+      - run: git tag --force last-sync main
+      - run: git push --force origin last-sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+name: Sync to l10n-central
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get install -y git-filter-repo mercurial
+      - run: sudo curl -O https://raw.githubusercontent.com/glandium/git-cinnabar/master/download.py
+        working-directory: /usr/local/bin
+      - run: sudo python download.py && sudo chmod a+rx git-cinnabar
+        working-directory: /usr/local/bin
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: git config
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config fetch.prune true
+          git config push.default upstream
+      - run: |
+          for lc in $(git diff-tree --no-commit-id --name-only l10n-central main); do
+            git remote add $lc hg::https://hg.mozilla.org/l10n-central/$lc/;
+            git fetch $lc;
+            git tag base-$lc l10n-central;
+            git branch next-$lc main;
+            git filter-repo --subdirectory-filter $lc --force --refs next-$lc base-$lc;
+            git checkout --track -b $lc $lc/branches/default/tip;
+            git cherry-pick base-$lc..next-$lc;
+            git push; # TODO: Authentication for hg.mozilla.org
+          done
+        shell: bash
+      - run: git tag --force l10n-central main
+      - run: git push --force origin l10n-central


### PR DESCRIPTION
We’re averaging about 100 localization commits a day, and it’s far too easy to imagine finding some issue with the new setup after a few days’ or even weeks’ operation. So I think it might make sense to initially sync commits from git to hg, so that we can switch back whenever.

Filing initially as a draft as the authentication for hg.mozilla.org is not yet included.