### PR TITLE
Use main rather than cthulhu branch in actions

### DIFF
--- a/.github/workflows/merge-locales.yml
+++ b/.github/workflows/merge-locales.yml
@@ -22,7 +22,6 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: sudo apt-get install -y git-filter-repo
-      - run: git checkout -b cthulhu
       - run: |
           while read lc; do
             git branch $lc origin/$lc;
@@ -33,6 +32,6 @@ jobs:
         shell: bash
       - run: git merge --no-edit $(tr '\n' ' ' < firefox-locales)
         shell: bash
-      - run: git push origin cthulhu
-      - run: git tag --force last-sync cthulhu
+      - run: git push origin main
+      - run: git tag --force last-sync
       - run: git push --force origin last-sync

--- a/.github/workflows/sync-to-locales.yml
+++ b/.github/workflows/sync-to-locales.yml
@@ -24,15 +24,15 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: |
-          for lc in $(git diff-tree --no-commit-id --name-only last-sync origin/cthulhu); do
+          for lc in $(git diff-tree --no-commit-id --name-only last-sync main); do
             git tag base-$lc last-sync;
-            git branch next-$lc origin/cthulhu;
+            git branch next-$lc main;
             git filter-repo --subdirectory-filter $lc --force --refs next-$lc base-$lc;
             git checkout --track origin/$lc;
             git cherry-pick base-$lc..next-$lc;
           done
         shell: bash
-      - run: git push origin $(git diff-tree --no-commit-id --name-only last-sync origin/cthulhu | tr '\n' ' ')
+      - run: git push origin $(git diff-tree --no-commit-id --name-only last-sync main | tr '\n' ' ')
         shell: bash
-      - run: git tag --force last-sync origin/cthulhu
+      - run: git tag --force last-sync main
       - run: git push --force origin last-sync


### PR DESCRIPTION
Seems like it's time to no longer be just testing the migration.

The `main` branch is the default for checkouts, hence not needing e.g. the `origin/` part in `sync-to-locales.yml`.

After `merge-locales.yml` is run with these changes, I'll file another PR dropping it and `update-from-hg.yml` from the repo.