### PR TITLE
Update tabContextMenu.ftl to be more in line with english word "dupli…

### DIFF
--- a/de/browser/browser/tabContextMenu.ftl
+++ b/de/browser/browser/tabContextMenu.ftl
@@ -18,10 +18,10 @@ tab-context-play-tabs =
     .label = Tabs wiedergeben
     .accesskey = w
 duplicate-tab =
-    .label = Tab klonen
+    .label = Tab duplizieren
     .accesskey = k
 duplicate-tabs =
-    .label = Tabs klonen
+    .label = Tabs duplizieren
     .accesskey = k
 # The following string is displayed on a menuitem that will close the tabs from the start of the tabstrip to the currently targeted tab (excluding the currently targeted and any other selected tabs).
 # In left-to-right languages this should use "Left" and in right-to-left languages this should use "Right".


### PR DESCRIPTION
…cate" (from english Firefox language) and closer commonality to the new option "doppelte tabs schließen" (both "duplicate" and "doppelt" start with same letter and are more similar. Easier for users to handle

Also, in the past this already was named "duplizieren". Why was this even renamed to "klonen" at some point?