### PR TITLE
Bug 1967258 - Update Bulgarian dictionary to 4.4.3

### DIFF
--- a/bg/extensions/spellcheck/hunspell/ChangeLog
+++ b/bg/extensions/spellcheck/hunspell/ChangeLog
@@ -1,0 +1,36 @@
+4.4.3 from 16.07.2020
+===================
+  * Updated chemical elements
+  * Added several new words
+  * Fixes
+
+
+4.4.2 from 19.10.2019
+===================
+  * Words duplication clean up
+  * Fixed installation script
+
+
+4.4.1 from 06.09.2019
+===================
+  * Updated install script.
+  * Updated readme file.
+  * Added more than 250 000 words.
+
+
+4.4.0 from 31.03.2015
+===================
+  * Updated install scripts.
+  * Added names of the settlements.
+
+
+4.2 from 15.04.2010
+===================
+  * Changed license from GPL to GPL/LGPL/MPL which will allow distribution by
+some programs that requires spell checking but does not like GPL such as OOo,
+Firefox, Chrome, etc.
+  * Added about 200 words.
+  * Started ChangeLog in English. All documents written before in Bulgarian will
+be replaced with English version. Old versions that are in Bulgarian will stay
+in repository, but will not be packaged. Only English version of docs will be
+distributed.

--- a/bg/extensions/spellcheck/hunspell/bg.aff
+++ b/bg/extensions/spellcheck/hunspell/bg.aff
@@ -1,5 +1,5 @@
-SET cp1251
-TRY аеонирвтсмлкпздяубъчгцжхшфйщюьАЕОНИРВТСМЛКПЗДЯУБЪЧГЦЖХШФЙЩЮЬ
+SET CP1251
+TRY аеониртвслмкпздяубъгчцжхшфйщюьАЕОНИРТВСЛМКПЗДЯУБЪГЧЦЖХШФЙЩЮЬ
 
 SFX A Y 8
 SFX A   0         а         .
@@ -235,16 +235,16 @@ SFX M   ец        ецо       ец
 SFX M   ец        ецът      ец
 SFX M   ец        йци       ец
 SFX M   ец        йците     ец
-SFX M   ин        и         ин
-SFX M   ин        ина       ин
-SFX M   ин        ино       ин
-SFX M   ин        инът      ин
-SFX M   ин        ите       ин
 SFX M   й         и         й
 SFX M   й         ите       й
 SFX M   й         ю         й
 SFX M   й         я         й
 SFX M   й         ят        й
+SFX M   ин        и         ин
+SFX M   ин        ина       ин
+SFX M   ин        ино       ин
+SFX M   ин        инът      ин
+SFX M   ин        ите       ин
 SFX M   о         и         о
 SFX M   о         ите       о
 SFX M   о         ото       о
@@ -280,6 +280,9 @@ SFX N   ър        ъра       ър
 SFX N   ър        ърът      ър
 
 SFX O Y 18
+SFX O   0         вци       .
+SFX O   0         вците     .
+SFX O   0         то        .
 SFX O   е         ето       е
 SFX O   е         ия        е
 SFX O   е         ията      е
@@ -291,55 +294,10 @@ SFX O   к         ка        к
 SFX O   к         кът       к
 SFX O   к         ци        к
 SFX O   к         ците      к
-SFX O   о         овци      о
-SFX O   о         овците    о
-SFX O   о         ото       о
 SFX O   х         си        х
 SFX O   х         сите      х
 SFX O   х         ха        х
 SFX O   х         хът       х
-
-SFX S Y 40
-SFX S   ам        а         ам
-SFX S   ам        ай        ам
-SFX S   ам        айки      ам
-SFX S   ам        айте      ам
-SFX S   ам        ал        ам
-SFX S   ам        ала       ам
-SFX S   ам        алата     ам
-SFX S   ам        али       ам
-SFX S   ам        алите     ам
-SFX S   ам        алия      ам
-SFX S   ам        алият     ам
-SFX S   ам        ало       ам
-SFX S   ам        алото     ам
-SFX S   ам        аме       ам
-SFX S   ам        ан        ам
-SFX S   ам        ана       ам
-SFX S   ам        аната     ам
-SFX S   ам        ани       ам
-SFX S   ам        аните     ам
-SFX S   ам        ания      ам
-SFX S   ам        аният     ам
-SFX S   ам        ано       ам
-SFX S   ам        аното     ам
-SFX S   ам        ат        ам
-SFX S   ам        ате       ам
-SFX S   ам        ах        ам
-SFX S   ам        аха       ам
-SFX S   ам        ахме      ам
-SFX S   ам        ахте      ам
-SFX S   ам        аш        ам
-SFX S   ам        аше       ам
-SFX S   ам        ащ        ам
-SFX S   ам        аща       ам
-SFX S   ам        ащата     ам
-SFX S   ам        ащи       ам
-SFX S   ам        ащите     ам
-SFX S   ам        ащия      ам
-SFX S   ам        ащият     ам
-SFX S   ам        ащо       ам
-SFX S   ам        ащото     ам
 
 SFX X Y 38
 SFX X   м         дат       м


### PR DESCRIPTION
Current version in tree: Probably 4.4.1 (440,102 words)

Sync with the much improved version 4.4.3 (699,185 words) on AMO.

Also adds a changelog file

GPL-2.0 / LGPL-2.1 / MPL-1.1