### PR TITLE
Add moz.l10n lint for changed files in PRs

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -20,3 +20,5 @@ jobs:
           gh pr diff --name-only |
           xargs ls -d1 2>/dev/null |
           python -m moz.l10n.bin.lint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: "pip install 'moz-l10n[xml]~=0.7.0'"
+      - run: >
+          gh pr diff --name-only |
+          xargs ls -d1 2>/dev/null |
+          python -m moz.l10n.bin.lint

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,11 +15,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: "pip install 'moz-l10n[xml]~=0.7.0'"
+      - run: "pip install 'moz.l10n[xml]~=0.7.1'"
       - run: >
           gh pr diff --name-only "$PR_URL" |
-          xargs ls -d1 2>/dev/null |
-          xargs python -m moz.l10n.bin.lint
+          xargs python -m moz.l10n.bin.lint --skip-unknown
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - run: >
           gh pr diff --name-only "$PR_URL" |
           xargs ls -d1 2>/dev/null |
-          python -m moz.l10n.bin.lint
+          xargs python -m moz.l10n.bin.lint
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -17,8 +17,9 @@ jobs:
           python-version: "3.12"
       - run: "pip install 'moz-l10n[xml]~=0.7.0'"
       - run: >
-          gh pr diff --name-only |
+          gh pr diff --name-only "$PR_URL" |
           xargs ls -d1 2>/dev/null |
           python -m moz.l10n.bin.lint
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Fixes #68

Checks that files added or changed in PRs can be parsed as valid localization files.