### PR TITLE
Add missing pt-BR version to dictionary README

### DIFF
--- a/pt-BR/extensions/spellcheck/hunspell/README.txt
+++ b/pt-BR/extensions/spellcheck/hunspell/README.txt
@@ -1,3 +1,4 @@
+version 123.2024.16.151
 *** ADENDO PARA A VERSÃO PT-BR ***
 
 A versão pt-BR foi criada como um trabalho derivado do dicionário


### PR DESCRIPTION
The pt-BR dictionary was updated in https://bugzilla.mozilla.org/show_bug.cgi?id=1874992 from https://addons.mozilla.org/pt-PT/firefox/addon/corretor/

I am adding the version of the extension it was updated from to have a future reference point.