### PR TITLE
Drop workaround for zh-TW font preferences

### DIFF
--- a/zh-TW/browser/firefox-l10n.js
+++ b/zh-TW/browser/firefox-l10n.js
@@ -4,15 +4,3 @@
 
 #filter substitution
 
-#ifdef XP_WIN
-
-// overwrite zh-CN defaults with zh-TW ones in win32 Firefox. (see bug 603549)
-// noted that below setting should change accordingly if setting in intl/all.js changes.
-pref("font.name.serif.zh-CN", "Times New Roman");
-pref("font.name.sans-serif.zh-CN", "Arial");
-pref("font.name.monospace.zh-CN", "細明體");  // MingLiU
-pref("font.name-list.serif.zh-CN", "新細明體,PMingLiu,細明體,MingLiU");
-pref("font.name-list.sans-serif.zh-CN", "新細明體,PMingLiU,細明體,MingLiU");
-pref("font.name-list.monospace.zh-CN", "MingLiU,細明體");
-
-#endif


### PR DESCRIPTION
Fixes [bug 1442619](https://bugzilla.mozilla.org/show_bug.cgi?id=1442619).

This workaround was introduced in [bug 603549](https://bugzilla.mozilla.org/show_bug.cgi?id=603549), with a note:
> The workaround here should be superseded by [bug 677919](https://bugzilla.mozilla.org/show_bug.cgi?id=677919) if it ever gets implemented.

That bug is still open, but at least [my understanding](https://bugzilla.mozilla.org/show_bug.cgi?id=729982#c2) is that the core issues was solved in [bug 1581822](https://bugzilla.mozilla.org/show_bug.cgi?id=1581822), and that this workaround is no longer necessary.

Edit: Bugs 677919 and 729982 are now closed as duplicates of 1581822.